### PR TITLE
Fix Deepseek assets path

### DIFF
--- a/samples/deepseek-r1-webgpu/index.html
+++ b/samples/deepseek-r1-webgpu/index.html
@@ -43,6 +43,6 @@
 
   <body>
     <div id="root"></div>
-    <script type="module" src="/src/main.jsx"></script>
+    <script type="module" src="./src/main.jsx"></script>
   </body>
 </html>


### PR DESCRIPTION
The 

```
     <script type="module" crossorigin src="/assets/index-D5M7JWjn.js"></script>
    <link rel="stylesheet" crossorigin href="/assets/index-DuNL__1m.css">
```
in view-source:https://intel.github.io/web-ai-showcase/samples/deepseek-r1-webgpu/index.html is wrong.

Expected:

```
    <script type="module" crossorigin src="/web-ai-showcase/assets/index-D5M7JWjn.js"></script>
    <link rel="stylesheet" crossorigin href="/web-ai-showcase/assets/index-DuNL__1m.css">
```

I am not quite sure if this PR can fix the issue, try it now.